### PR TITLE
Add option to log all new posts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 ## Overview
 
 
-This program monitors new submissions in specific subreddits for specific keywords, making it easy to parse information about topics of interest. If one of the provided keywords is encountered, information about the submission (namely, title, date, url, and id) is logged for later viewing. The program continuously monitors the subreddits until the program is terminated.
+This program monitors new submissions in specific subreddits. It can log all new posts, or it can monitor for specific keywords, making it easy to parse information about topics of interest. If one of the provided keywords is encountered, information about the submission (namely, title, date, url, id, and body) is logged for later viewing. The program continuously monitors the subreddits until the program is terminated (Ctrl+C).
 
-As an example, consider a case in which you're interested in finding new recipes for tacos. In such a case, subreddit-pulse could monitor cooking-related subreddits for the keywords 'taco' and 'tacos', and it will log each new submission that includes these keywords. Later, a review of the generated log file will show all new submisisons that discuss tacos, ensuring that no new recipes are missed.
+As an example, consider a case in which you're interested in finding new recipes for tacos. In such a case, subreddit-pulse could monitor cooking-related subreddits for the keywords 'taco' and 'tacos', and it will log each new submission that includes these keywords. Later, a review of the generated log file will show all new submissions that discuss tacos, ensuring that no new recipes are missed.
 
 ## Installation 
 
 
-This program was written in Python 3. Clone this repository, and then create a virtual environment:\
+This program was written using Python 3.6.7. To use, clone this repository, and then create a virtual environment:\
 `python3 -m venv venv`\
 Activate the virtual environment:\
 `source venv/bin/activate` (for Linux/OS X)\
@@ -24,15 +24,21 @@ Install the required dependencies:\
 After installation, the config.ini file needs to be setup. This file provides the necessary information for accessing Reddit. An example of how the config.ini file should be setup is located in `examples/`. The completed config.ini file should be placed in `subreddit_pulse/`. 
 
 
-Next, the keywords of interest need to be added. By default, the program looks for a file called keywords.dat in the root directory. This file should contain keywords of interest, each on its own line. An example keywords.dat file is located in `examples/`.
+Next, for keyword-based logging, the keywords of interest need to be added. By default, the program looks for a file called keywords.dat in the root directory. This file should contain keywords of interest, each on its own line. An example keywords.dat file is located in `examples/`.
 
 
 ## Usage
 
+### Log all new posts
 
-After setting up config.ini and keywords.dat, the program can be launched as follows:
-`python subreddit_pulse.py --subreddits 'subreddit-name'`, where _subreddit-name_ is the subreddit to search. Multiple subreddits can be specified if their names are separated by a '+' sign, e.g., "subreddit1+subreddit2+subreddit3".
+To log all new posts:\
+`python subreddit_pulse.py all --subreddits subreddit_name --log name_of_log_file`\
+By default, if a log file is not specified, one will automatically be created with the format "YearMonthDay-HourMinuteSecond.csv". If no subreddits are specified, the program will prompt for the name(s) of subreddit(s) to monitor. Multiple subreddits can be specified if their names are separated by a '+' sign, e.g., "subreddit1+subreddit2+subreddit3".
 
+### Log posts that contain specific keywords
 
-Once launched, the program will monitor a continuous stream of new submissions from the subreddit(s). If one of the keywords is encountered in the title or the body of the submission, then the submission title, date created, URL, and ID are appended to a log file (located in `logfiles/`). A new logfile is written each time the program is launched (with the name format "YearMonthDay-HourMinuteSecond.csv"). 
+To log posts that contain specific keywords:\
+`python subreddit_pulse.py keywords --subreddits subreddit_name --log name_of_log_file --search_terms name_of_keywords_file`\
+
+By default, if a log file is not specified, one will automatically be created with the format "YearMonthDay-HourMinuteSecond.csv". If a keywords file is not specified, the program will default to `keywords.dat`. If no subreddits are specified, the program will prompt for the name(s) of subreddit(s) to monitor. Multiple subreddits  can be specified if their names are separated by a '+' sign, e.g., "subreddit1+subreddit2+subreddit3".
 

--- a/subreddit_pulse.py
+++ b/subreddit_pulse.py
@@ -39,7 +39,7 @@ def watch_subreddit_keywords(subreddits, search_terms, log):
     monitor = SubredditMonitor()
     monitor.logfile = logfile
     monitor.keyword_file = search_terms
-    monitor.subreddit_monitor(subreddits)
+    monitor.subreddit_monitor_keywords(subreddits)
 
 
 @cli.command('all')
@@ -48,7 +48,7 @@ def watch_subreddit_keywords(subreddits, search_terms, log):
     prompt='Subreddits to monitor.',
     help="Subreddits to monitor. Use '+' to join multiple.")
 @click.option('--log', help="Name for log file. Default is <date>.csv")
-def watch_subreddit_all(subreddits):
+def watch_subreddit_all(subreddits, log):
     """Logs all posts from specific subreddits.
 
     For specified subreddits, logs all posts to log file for later
@@ -56,7 +56,10 @@ def watch_subreddit_all(subreddits):
     subreddit names with '+', e.g., 'askreddit+gifs+learnpython'. The
     log file is stored in logfiles/.
     """
-    pass
+    logfile = _create_logfile(log)
+    monitor = SubredditMonitor()
+    monitor.logfile = logfile
+    monitor.subreddit_monitor_all(subreddits)
 
 
 def _create_logfile(log):
@@ -71,7 +74,7 @@ def _create_logfile(log):
         time_string = time.strftime("%Y%m%d-%H%M%S")
         with open(f"logfiles/{time_string}.csv", 'w') as f:
             f.write("Title,ID,URL,Date_Created,Body\n")
-            print(f"Log file ({time_string.csv}) created")
+            print(f"Log file ({time_string}.csv) created")
         return f"logfiles/{time_string}.csv"
     elif log:
         with open(f"logfiles/{log}", 'w') as f:

--- a/subreddit_pulse.py
+++ b/subreddit_pulse.py
@@ -3,42 +3,82 @@ import time
 import click
 
 
-@click.command()
-@click.option('--subreddits',
-              default='askreddit',
-              help="Subreddits to monitor. Use '+' to join multiple.")
-@click.option('--search_terms',
-              default='keywords.dat',
-              help="File containing search terms for monitoring subreddits.")
-def watch_subreddit(subreddits, search_terms):
-    """Subreddit Pulse: Monitors Subreddits for Specific Terms
+@click.group()
+def cli():
+    """Subreddit Pulse.
 
-    When given a list of specific terms, this program monitors specific
-    subreddits for those terms. If the term is found in the title or body
-    of a new submission, information about the submission is recorded into
-    a logfile (stored in logfiles/).
+    Watches specific subreddits and logs new submissions. Can log
+    all new submissions or can log only submissions that contain
+    user-provided keywords.
+
+    For help on specific commands, include --help after the command.
     """
-    logfile = _create_logfile()
+    pass
+
+
+@cli.command('keywords')
+@click.option(
+    '--subreddits',
+    prompt='Subreddits to monitor.',
+    help="Subreddits to monitor. Use '+' to join multiple.")
+@click.option(
+    '--search_terms',
+    default='keywords.dat',
+    help="File containing search terms for monitoring subreddits.")
+@click.option('--log', help="Name for log file. Default is <date>.csv")
+def watch_subreddit_keywords(subreddits, search_terms, log):
+    """Logs posts that contain specific keywords.
+
+    Given a list of specific terms, monitors specified
+    subreddits for those terms. If the keyword is found in the title
+    or body of the post, then the post is logged in a log file (located
+    in logfiles/. Multiple subreddits can be specified by separating the
+    subreddit names with '+', e.g., 'askreddit+learnpython'.
+    """
+    logfile = _create_logfile(log)
     monitor = SubredditMonitor()
     monitor.logfile = logfile
     monitor.keyword_file = search_terms
     monitor.subreddit_monitor(subreddits)
 
 
-def _create_logfile():
+@cli.command('all')
+@click.option(
+    '--subreddits',
+    prompt='Subreddits to monitor.',
+    help="Subreddits to monitor. Use '+' to join multiple.")
+@click.option('--log', help="Name for log file. Default is <date>.csv")
+def watch_subreddit_all(subreddits):
+    """Logs all posts from specific subreddits.
+
+    For specified subreddits, logs all posts to log file for later
+    analysis. Multiple subreddits can be specified by separating the
+    subreddit names with '+', e.g., 'askreddit+gifs+learnpython'. The
+    log file is stored in logfiles/.
+    """
+    pass
+
+
+def _create_logfile(log):
     """Creates a new logfile.
 
     This log file is used to log submissions that meet
     certain criteria. A new log file is generated each
-    time the program is executed. The logfile name is
+    time the program is executed. The default logfile name is
     of the form YearMonthDay-HourMinuteSecond.csv
     """
-    time_string = time.strftime("%Y%m%d-%H%M%S")
-    with open(f"logfiles/{time_string}.csv", 'w') as f:
-        f.write("Title,ID,URL,Date_Created\n")
-    print("Log file created")
-    return f"logfiles/{time_string}.csv"
+    if not log:
+        time_string = time.strftime("%Y%m%d-%H%M%S")
+        with open(f"logfiles/{time_string}.csv", 'w') as f:
+            f.write("Title,ID,URL,Date_Created,Body\n")
+            print(f"Log file ({time_string.csv}) created")
+        return f"logfiles/{time_string}.csv"
+    elif log:
+        with open(f"logfiles/{log}", 'w') as f:
+            f.write("Title,ID,URL,Date_Created,Body\n")
+            print(f"Log file ({log}) created.")
+        return f"logfiles/{log}"
 
 
 if __name__ == "__main__":
-    watch_subreddit()
+    cli()

--- a/subreddit_pulse/subreddit_monitor.py
+++ b/subreddit_pulse/subreddit_monitor.py
@@ -10,7 +10,7 @@ class SubredditMonitor(object):
         self.logfile = "logfile.csv"
         self.keyword_file = "keywords.dat"
 
-    def subreddit_monitor(self, subreddits):
+    def subreddit_monitor_keywords(self, subreddits):
         """Monitors new submissions for keywords.
 
         This function monitors the title/body of new submissions for given
@@ -33,6 +33,19 @@ class SubredditMonitor(object):
                 self._log_submissions(submission)
             else:
                 print("Passing. Submission does not satisfy criteria.")
+
+    def subreddit_monitor_all(self, subreddits):
+        """Logs all new submissions for given subreddits.
+
+        Args:
+        subreddits (str): subreddits to monitor; multiple subreddits
+        can be included in string when separated by '+' sign, e.g.,
+        subreddit1+subreddit2+subreddit3.
+        """
+        reddit = self._reddit_access()
+        for submission in reddit.subreddit(subreddits).stream.submissions():
+            print("Logging submission.")
+            self._log_submissions(submission)
 
     def _reddit_access(self):
         """Returns reddit object for accessing subreddits."""
@@ -60,8 +73,9 @@ class SubredditMonitor(object):
         title = submission.title
         sub_id = submission.id
         url = submission.url
+        body = submission.selftext
         date_created = dt.datetime.fromtimestamp(submission.created)
-        log_string = f"{title},{sub_id},{url},{date_created}\n"
+        log_string = f"{title},{sub_id},{url},{date_created},{body}\n"
         with open(self.logfile, 'a') as f:
             f.write(log_string)
 


### PR DESCRIPTION
Summary:

Occasionally, when interested in a specific topic, you're not initially sure of which keywords will provide the most useful search results. Thus, this PR adds functionality to log all new submissions for specific subreddits so the data can be parsed for more focused searches later. The CLI has been updated to reflect this new functionality, and the option to specify the name for the log file has also been included.